### PR TITLE
Apply spoilers to embedded posts as well

### DIFF
--- a/assets/javascripts/spoiler_alert_main.js
+++ b/assets/javascripts/spoiler_alert_main.js
@@ -20,6 +20,7 @@
       Discourse.PostView.prototype.on("postViewInserted", applySpoilers);
       Discourse.ComposerView.prototype.on("previewRefreshed", applySpoilers);
       Discourse.UserStreamView.prototype.on("didInsertElement", applySpoilers);
+      Discourse.EmbeddedPostView.prototype.on("didInsertElement", applySpoilers);
     });
 
   });


### PR DESCRIPTION
Just realized that spoilers weren't working on the embedded posts as well.
