### PR TITLE
FIX: make plugin compatible with dark theme

### DIFF
--- a/assets/javascripts/spoiler.js
+++ b/assets/javascripts/spoiler.js
@@ -4,8 +4,8 @@
       globalIdCounter = 0;
 
   var blurText = function($spoiler, radius) {
-    var textShadow = "black 0 0 " + radius + "px";
-    if (isIE) { textShadow = radius <= 0 ? "0 0 0 0 black" : "0 0 " + radius + "px .1px black"; }
+    var textShadow = "gray 0 0 " + radius + "px";
+    if (isIE) { textShadow = radius <= 0 ? "0 0 0 0 gray" : "0 0 " + radius + "px .1px gray"; }
 
     $spoiler.css("background-color", "transparent")
             .css("color", "rgba(0, 0, 0, 0)")


### PR DESCRIPTION
Currently the plugin is not compatible with dark themes due to black shadow, changed it to gray to make it compatible with dark theme as well as light theme.

Example:
- For dark theme:
  ![screen shot 2014-08-29 at 17 39 32](https://cloud.githubusercontent.com/assets/5732281/4090184/25358680-2f7a-11e4-8b3d-58e99ce84878.png)
  ![screen shot 2014-08-29 at 17 40 47](https://cloud.githubusercontent.com/assets/5732281/4090185/25f183bc-2f7a-11e4-8922-2dfe9813fab5.png)
- For light theme:
  ![screen shot 2014-08-29 at 17 37 45](https://cloud.githubusercontent.com/assets/5732281/4090182/252375ee-2f7a-11e4-9857-ffcdea2934ea.png)
  ![screen shot 2014-08-29 at 17 37 56](https://cloud.githubusercontent.com/assets/5732281/4090183/25296d1e-2f7a-11e4-977f-f586e42a331b.png)
