### PR TITLE
Adds support for applying spoiler effects to both images and text

### DIFF
--- a/assets/javascripts/initializers/spoiler-alert.js.es6
+++ b/assets/javascripts/initializers/spoiler-alert.js.es6
@@ -7,15 +7,9 @@ export default {
   name: "apply-spoilers",
   initialize: function(container) {
     decorateCooked(container, function($elem) {
-      // text
-      $('.spoiler:not(:has(img))', $elem).removeClass('spoiler')
-                                         .addClass('spoiled')
-                                         .spoilText();
-      // images
-      $('.spoiler:has(img)', $elem).removeClass('spoiler')
-                                   .addClass('spoiled')
-                                   .wrap("<div style='display: inline-block; overflow: hidden;'></div>")
-                                   .spoilImage();
+      $('.spoiler', $elem).removeClass('spoiler')
+                           .addClass('spoiled')
+                           .spoil()
     });
   }
 };

--- a/assets/javascripts/spoiler.js
+++ b/assets/javascripts/spoiler.js
@@ -1,7 +1,12 @@
 (function($) {
 
   var isIE = /*@cc_on!@*/false || document.documentMode,
-      globalIdCounter = 0;
+      globalIdCounter = 0,
+      DEFAULTS = {
+        max: {text: 10, image: 20},
+        partial: {text:5, image: 6}
+      };
+
 
   var blurText = function($spoiler, radius) {
     var textShadow = "gray 0 0 " + radius + "px";
@@ -15,9 +20,10 @@
   var blurImage = function($spoiler, radius) {
     // on the first pass, transform images into SVG
     $("img", $spoiler).each(function(index, image) {
+      var isEmoji = $(this).hasClass('emoji');
       var transform = function() {
-        var w = image.width,
-            h = image.height,
+        var w = isEmoji ? 20 : image.width,
+            h = isEmoji ? 20 : image.height,
             id = ++globalIdCounter;
         var svg = "<svg data-spoiler-id='" + id + "' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='" + w + "' height='" + h + "'>" +
                   "<defs><filter id='blur-" + id + "'><feGaussianBlur id='gaussian-" + id + "' stdDeviation='" + radius + "'></feGaussianBlur></filter></defs>" +
@@ -40,9 +46,15 @@
     });
   };
 
-  var applySpoilers = function($spoiler, options, applyBlur) {
+  var applyBlur = function($spoiler, option) {
+    blurText($spoiler, option.text);
+    blurImage($spoiler, option.image);
+  };
+
+  var applySpoilers = function($spoiler, options) {
     var maxBlur = options.max,
-        partialBlur = options.partial;
+        partialBlur = options.partial,
+        noBlur = {text: 0, image: 0};
 
     $spoiler.data("spoiler-state", "blurred");
 
@@ -56,7 +68,7 @@
     }).on("click", function(e) {
       if ($spoiler.data("spoiler-state") === "blurred") {
         $spoiler.data("spoiler-state", "revealed").css("cursor", "auto");
-        applyBlur($spoiler, 0);
+        applyBlur($spoiler, noBlur);
       } else {
         $spoiler.data("spoiler-state", "blurred").css("cursor", "pointer");
         applyBlur($spoiler, partialBlur);
@@ -66,21 +78,10 @@
 
   };
 
-  $.fn.spoilText = function(options) {
-    var defaults = { max: 10, partial: 5 },
-        opts = $.extend(defaults, options || {});
-
-    return this.each(function() {
-      applySpoilers($(this), opts, blurText);
-    });
-  };
-
-  $.fn.spoilImage = function(options) {
-    var defaults = { max: 20, partial: 6 },
-        opts = $.extend(defaults, options || {});
-
-    return this.each(function() {
-      applySpoilers($(this), opts, blurImage);
+  $.fn.spoil = function(options) {
+    var opts = $.extend(DEFAULTS, options || {});
+    return this.each(function () {
+      applySpoilers($(this), opts);
     });
   };
 

--- a/assets/stylesheets/discourse_spoiler_alert.css
+++ b/assets/stylesheets/discourse_spoiler_alert.css
@@ -1,0 +1,7 @@
+.spoiled .lightbox .meta {
+    display: none;
+}
+
+.spoiled svg {
+    vertical-align: middle;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,3 +5,4 @@
 # url: https://github.com/discourse/discourse-spoiler-alert
 
 register_asset "javascripts/spoiler.js"
+register_asset "stylesheets/discourse_spoiler_alert.css"


### PR DESCRIPTION
Allows the application of blur effects to both images and text in a single spoiler tag.

Fix for https://meta.discourse.org/t/spoiler-does-not-support-emoji/29902, this also requires https://github.com/discourse/discourse/pull/3668

Initial:
<img width="1341" alt="screen shot 2015-08-18 at 5 48 40 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346487/52b6dfd6-45d2-11e5-94d6-a4445b00b48a.png">

Hover:
<img width="1358" alt="screen shot 2015-08-18 at 5 48 54 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346490/6124a03a-45d2-11e5-8871-f2f43a8fc648.png">

Blur:
<img width="1347" alt="screen shot 2015-08-18 at 5 49 07 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346492/65658a6a-45d2-11e5-8bbe-090b5c053624.png">
