### PR TITLE
FIX: Lazily Loading images did not work with spoilers

### DIFF
--- a/assets/javascripts/initializers/spoiler-alert.js.es6
+++ b/assets/javascripts/initializers/spoiler-alert.js.es6
@@ -86,9 +86,7 @@ export default {
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
     if (siteSettings.spoiler_enabled) {
-      withPluginApi("0.5", initializeSpoiler, {
-        noApi: () => decorateCooked(container, spoil)
-      });
+      withPluginApi("0.5", initializeSpoiler);
     }
   }
 };


### PR DESCRIPTION
This is the result of using SVG for spoilered images, which is only
necessary for IE11.

While it's a nice hack, it's a bunch of extra logic that needn't be
applied in most browsers, and was causing issues with our image lazy
loading code, so I've elected to remove it.

Now, in IE11 the images will be not shown until clicked rather than
blurred, which I think is a decent compromise for a 5+ year old web
browser.