### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/spoiler-button-test.js
+++ b/test/javascripts/acceptance/spoiler-button-test.js
@@ -24,6 +24,9 @@ acceptance("Spoiler Button", function (needs) {
     assert.ok(exists("#create-topic"), "the create button is visible");
 
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
     await popUpMenu.expand();
     await popUpMenu.selectRowByValue("insertSpoiler");
 


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.