### PR TITLE
A11Y: Toggle spoiler via keyboard and improve screen reader support

### DIFF
--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -1,3 +1,5 @@
+import I18n from "I18n";
+
 const INTERACTIVE_SELECTOR = [
   "a",
   "area",

--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -34,10 +34,16 @@ function _setSpoilerHidden(element) {
     "aria-label": I18n.t("spoiler.label.show"),
   };
 
+  // Set default attributes & classes on spoiler
   Object.entries(spoilerHiddenAttributes).forEach(([key, value]) => {
     element.setAttribute(key, value);
   });
   element.classList.add("spoiler-blurred");
+
+  // Set aria-hidden for all children of the spoiler
+  Array.from(element.children).forEach((e) => {
+    e.setAttribute("aria-hidden", true);
+  });
 }
 
 function _setSpoilerVisible(element) {
@@ -47,10 +53,16 @@ function _setSpoilerVisible(element) {
     "aria-label": I18n.t("spoiler.label.hide"),
   };
 
+  // Set attributes & classes for when spoiler is visible
   Object.entries(spoilerVisibleAttributes).forEach(([key, value]) => {
     element.setAttribute(key, value);
   });
   element.classList.remove("spoiler-blurred");
+
+  // Remove aria-hidden for all children of the spoiler when visible
+  Array.from(element.children).forEach((e) => {
+    e.removeAttribute("aria-hidden");
+  });
 }
 
 function toggleSpoiler(event, element) {

--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -23,18 +23,53 @@ function isInteractive(event) {
   return event.defaultPrevented || event.target.closest(INTERACTIVE_SELECTOR);
 }
 
-export default function applySpoiler(element) {
-  element.setAttribute("data-spoiler-state", "blurred");
+function _setSpoilerHidden(element) {
+  const spoilerHiddenAttributes = {
+    role: "button",
+    tabindex: "0",
+    "data-spoiler-state": "blurred",
+    "aria-expanded": false,
+    "aria-label": I18n.t("spoiler.label.show"),
+  };
+
+  Object.entries(spoilerHiddenAttributes).forEach(([key, value]) => {
+    element.setAttribute(key, value);
+  });
   element.classList.add("spoiler-blurred");
+}
+
+function _setSpoilerVisible(element) {
+  const spoilerVisibleAttributes = {
+    "data-spoiler-state": "revealed",
+    "aria-expanded": true,
+    "aria-label": I18n.t("spoiler.label.hide"),
+  };
+
+  Object.entries(spoilerVisibleAttributes).forEach(([key, value]) => {
+    element.setAttribute(key, value);
+  });
+  element.classList.remove("spoiler-blurred");
+}
+
+function toggleSpoiler(event, element) {
+  if (element.getAttribute("data-spoiler-state") === "blurred") {
+    _setSpoilerVisible(element);
+    event.preventDefault();
+  } else if (!isInteractive(event)) {
+    _setSpoilerHidden(element);
+  }
+}
+
+export default function applySpoiler(element) {
+  _setSpoilerHidden(element);
 
   element.addEventListener("click", (event) => {
-    if (element.getAttribute("data-spoiler-state") === "blurred") {
-      element.setAttribute("data-spoiler-state", "revealed");
-      element.classList.remove("spoiler-blurred");
-      event.preventDefault();
-    } else if (!isInteractive(event)) {
-      element.setAttribute("data-spoiler-state", "blurred");
-      element.classList.add("spoiler-blurred");
+    toggleSpoiler(event, element);
+  });
+
+  element.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      toggleSpoiler(event, element);
     }
   });
 }

--- a/assets/stylesheets/discourse_spoiler_alert.scss
+++ b/assets/stylesheets/discourse_spoiler_alert.scss
@@ -14,7 +14,10 @@
 .spoiler-blurred {
   @include unselectable;
   cursor: pointer;
-  filter: blur(0.5em);
+
+  > * {
+    filter: blur(0.5em);
+  }
 
   a,
   area,

--- a/assets/stylesheets/discourse_spoiler_alert.scss
+++ b/assets/stylesheets/discourse_spoiler_alert.scss
@@ -14,10 +14,7 @@
 .spoiler-blurred {
   @include unselectable;
   cursor: pointer;
-
-  > * {
-    filter: blur(0.5em);
-  }
+  filter: blur(0.5em);
 
   a,
   area,

--- a/assets/stylesheets/discourse_spoiler_alert.scss
+++ b/assets/stylesheets/discourse_spoiler_alert.scss
@@ -42,7 +42,8 @@
   }
 
   .discourse-no-touch & {
-    &:hover {
+    &:hover,
+    &:focus {
       filter: blur(0.18em);
 
       img {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,5 +2,8 @@ en:
   js:
     spoiler:
       title: Blur Spoiler
+      label:
+        show: "Show hidden content"
+        hide: "Hide content"
     composer:
       spoiler_text: "This text will be blurred"


### PR DESCRIPTION
**This PR improves accessibility for spoilers by:**
- adding various necessary attributes such as:
   - `aria-label`
   - `aria-expanded`
   - `role="button"`
   - `tabindex="0"`
- ability to toggle spoilers via <kbd>Tab</kbd> to focus over and <kbd>Enter</kbd> to show/hide spoiler
- slightly alters blurring CSS to apply to elements inside spoiler's wrapping `<div>` so that outline when focusing is not blurred, instead only elements inside the `<div>` are blurred.

A little tricky to test as the testing environment is not picking up the event listener, and it doesn't seem too crucial to test anyway.