### PR TITLE
A11Y: Read spoiler after expanding

### DIFF
--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -51,6 +51,7 @@ function _setSpoilerVisible(element) {
     "data-spoiler-state": "revealed",
     "aria-expanded": true,
     "aria-label": I18n.t("spoiler.label.hide"),
+    "aria-live": "polite",
   };
 
   // Set attributes & classes for when spoiler is visible


### PR DESCRIPTION
**Context:**
A previous fix (https://github.com/discourse/discourse-spoiler-alert/pull/94) improved accessibility by allowing spoilers to be toggled via keyboard, however, this resulted in an issue where the spoiler contents cannot be read at all even after expanding.

**Overview:**
This PR fixes this issue by adding the `aria-live: polite` attribute to the spoiler **once expanded** so that the spoiler contents are read once the spoiler is toggled to be revealed.

**Related Meta Topic:**
https://meta.discourse.org/t/spoiler-issues-with-voiceover/257450/3

**Tests:**
Same as previous A11Y, a little tricky to test as the testing environment is not picking up the event listener, and it doesn't seem too crucial to test anyway.


**Screen Recording:**

https://user-images.githubusercontent.com/30090424/223888677-fe134289-5030-46ba-9008-d03132c7d0b2.mov


