### PR TITLE
Accessibility improvements

### DIFF
--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -47,6 +47,7 @@ function _setSpoilerHidden(element) {
     "data-spoiler-state": "blurred",
     "aria-expanded": false,
     "aria-label": I18n.t("spoiler.label.show"),
+    "aria-live": "polite",
   };
 
   // Set default attributes & classes on spoiler
@@ -64,7 +65,6 @@ function _setSpoilerVisible(element) {
     "data-spoiler-state": "revealed",
     "aria-expanded": true,
     "aria-label": null,
-    "aria-live": "polite",
     role: null,
   };
 

--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -25,6 +25,21 @@ function isInteractive(event) {
   return event.defaultPrevented || event.target.closest(INTERACTIVE_SELECTOR);
 }
 
+function no_text_selected(): boolean {
+  return (window.getSelection() + '') === ''
+}
+
+function setAttributes(element, attributes) {
+  Object.entries(attributes).forEach(([key, value]) => {
+    if (value === null) {
+      element.removeAttribute(key);
+    }
+    else {
+      element.setAttribute(key, value);
+    }
+  });
+}
+
 function _setSpoilerHidden(element) {
   const spoilerHiddenAttributes = {
     role: "button",
@@ -35,9 +50,7 @@ function _setSpoilerHidden(element) {
   };
 
   // Set default attributes & classes on spoiler
-  Object.entries(spoilerHiddenAttributes).forEach(([key, value]) => {
-    element.setAttribute(key, value);
-  });
+  setAttributes(element, spoilerHiddenAttributes);
   element.classList.add("spoiler-blurred");
 
   // Set aria-hidden for all children of the spoiler
@@ -50,15 +63,13 @@ function _setSpoilerVisible(element) {
   const spoilerVisibleAttributes = {
     "data-spoiler-state": "revealed",
     "aria-expanded": true,
-    //"aria-label": I18n.t("spoiler.label.hide"),
+    "aria-label": null,
     "aria-live": "polite",
+    role: null,
   };
 
   // Set attributes & classes for when spoiler is visible
-  element.removeAttribute("aria-label");
-  Object.entries(spoilerVisibleAttributes).forEach(([key, value]) => {
-    element.setAttribute(key, value);
-  });
+  setAttributes(element, spoilerHiddenAttributes);
   element.classList.remove("spoiler-blurred");
 
   // Remove aria-hidden for all children of the spoiler when visible
@@ -71,7 +82,7 @@ function toggleSpoiler(event, element) {
   if (element.getAttribute("data-spoiler-state") === "blurred") {
     _setSpoilerVisible(element);
     event.preventDefault();
-  } else if (!isInteractive(event)) {
+  } else if (!isInteractive(event) && no_text_selected()) {
     _setSpoilerHidden(element);
   }
 }

--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -25,8 +25,8 @@ function isInteractive(event) {
   return event.defaultPrevented || event.target.closest(INTERACTIVE_SELECTOR);
 }
 
-function no_text_selected(): boolean {
-  return (window.getSelection() + '') === ''
+function no_text_selected() {
+  return (window.getSelection() + '') === '';
 }
 
 function setAttributes(element, attributes) {

--- a/assets/javascripts/lib/apply-spoiler.js
+++ b/assets/javascripts/lib/apply-spoiler.js
@@ -69,7 +69,7 @@ function _setSpoilerVisible(element) {
   };
 
   // Set attributes & classes for when spoiler is visible
-  setAttributes(element, spoilerHiddenAttributes);
+  setAttributes(element, spoilerVisibleAttributes);
   element.classList.remove("spoiler-blurred");
 
   // Remove aria-hidden for all children of the spoiler when visible


### PR DESCRIPTION
Fix for https://meta.discourse.org/t/spoiler-issues-with-voiceover/257450/15

- Most important is to remove `aria-label` when unblurring, as it is read by screen readers instead of the entire content.
- I also removed the `role` as it resulted in "Button" being read in front of unblurred spoilers, and it didn't seem quite as necessary to explicitly state it's a button to reblur the spoiler.
- I made it so that if you're selecting text in an unblurred spoiler it won't reblur.
- I moved the `aria-live: polite` to the beginning as I had a report that Voiceover was reading unblurred text twice. I'm not certain that applying `aria-live` when it did was the cause, or that this is the solution, but it doesn't seem to cause any issues now.