### PR TITLE
FIX: User a regular string for admin notification.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -9,8 +9,6 @@
 
 after_initialize do
   AdminDashboardData.add_problem_check do
-    I18n.t(
-      "The discourse-spoiler-alert plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container.",
-    )
+    "The discourse-spoiler-alert plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container."
   end
 end


### PR DESCRIPTION
This is also what we have done for another plugin that was added to
core: https://github.com/discourse/discourse-checklist/blob/main/plugin.rb#L12
